### PR TITLE
Center the map in mobile mode, resize tweets, fix description, grammar and punctuation.

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -26,7 +26,7 @@
     <meta name="description" content="PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community and it attracts the best Python programmers from across the country and abroad.">
     <meta name="author" content="Pycon India">
     <link rel="shortcut icon" href="favicon.png">
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
     <!-- Global CSS -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <!-- Plugins CSS -->
@@ -160,7 +160,7 @@
 
                     <p>All communication should be appropriate for a professional audience, including people from many different backgrounds. Sexual language or imagery is inappropriate for all aspects of the conference, including talks. Remember that sexist, racist or any other form of exclusionary or offensive jokes or excessive public swearing are not appropriate at any venue of PyCon India.</p>
 
-                    <p>Do not insult or put down attendees or engage in any action that violates the open, welcoming and sharing spirit of the conference. Be kind and sensitive to the people around you when you are attending the conference, and avoid any kind of offensive or degrading behavior</p>.
+                    <p>Do not insult or put down attendees or engage in any action that violates the open, welcoming and sharing spirit of the conference. Be kind and sensitive to the people around you when you are attending the conference, and avoid any kind of offensive or degrading behavior.</p>
 
                     <p>If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -446,7 +446,7 @@ pre code {
 .venue .item {
     position: relative;
     padding: 60px;
-    padding-top: 0px;
+    padding-top: 10px;
 }
 .venue .item img {
     border-radius: 10px;
@@ -500,6 +500,10 @@ pre code {
     overflow: hidden;
     position: relative;
     margin: 0 auto;
+}
+
+.circularmap {
+    padding-top: 10px;
 }
 /* ======= Sponsors Section ======= */
 

--- a/faq.html
+++ b/faq.html
@@ -139,7 +139,7 @@
                   <span> Conference day (Oct 3rd and 4th): 08:00 AM - 5.30 PM.</span>
                 </p><br>
                 <p>
-                  <span><b> Q. What all does the Conference ticket(Oct 3&4) include? </b><br></span>
+                  <span><b> Q. What all does the Conference ticket(Oct 3 &amp; 4) include? </b><br></span>
                   <span>A. Full conference pass for two days. <br>Breakfast, Lunch and Hi-Tea.<br>It also includes the PyCon India T-shirt which will be distributed on Oct 4.</span>
                 </p>
 

--- a/faq.html
+++ b/faq.html
@@ -26,7 +26,7 @@
     <meta name="description" content="PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community and it attracts the best Python programmers from across the country and abroad.">
     <meta name="author" content="Pycon India">
     <link rel="shortcut icon" href="favicon.png">
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
     <!-- Global CSS -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <!-- Plugins CSS -->
@@ -123,7 +123,7 @@
 
                 <p>
                   <span><b>Q. How do I upload presentations to the site?</b><br></span>
-                  <span>A. We don't support presentation uploads yet. Please upload your presentation to a public site such as slideshare or google docs and use that link in your talk's description</span>
+                  <span>A. We don't support presentation uploads yet. Please upload your presentation to a public site such as SlideShare or Google Docs and use that link in your talk's description.</span>
                 </p><br>
                 <p>
                   <span><b>Q. My question is not listed here / I am still unclear about a few things. Whom should I contact?</b><br></span>

--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community and it attracts the best Python programmers across the country and abroad.">
+    <meta name="description" content="PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community and it attracts the best Python programmers from across the country and abroad.">
     <meta name="author" content="Pycon India">
     <link rel="shortcut icon" href="favicon.png">
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
     <!-- Global CSS -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <!-- Plugins CSS -->
@@ -145,7 +145,7 @@ PYCON
             <div class="col-md-6">
 
                 <p class="intro">
-                    PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community. It attracts the best Python programmers across the country and abroad.
+                    PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community. It attracts the best Python programmers from across the country and abroad.
                 </p>
                 <div class="col-md-6">
                     <br/>
@@ -888,8 +888,8 @@ PYCON
             <div class="gmap-area">
                 <div class="container">
                     <div class="row">
-                        <div class="col-md-5 text-center">
-                            <div class="gmapborder">
+                        <div class="col-md-5 text-center circularmap">
+                            <div class="gmapborder center-block">
                                 <div class="gmap">
                                     <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3888.4487450641623!2d77.596864!3d12.943112!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0000000000000000%3A0xc4498066da178922!2sNIMHANS+Convention+Centre!5e0!3m2!1sen!2sin!4v1422701360578" width="600" height="450" frameborder="0" style="border:0">
                                     </iframe>
@@ -1155,7 +1155,7 @@ Goibibo.com enables travellers to search, compare and buy from across categories
                         <!-- start sw-rss-feed code -->
     <!-- start feedwind code -->
     <script type="text/javascript">document.write('\x3Cscript type="text/javascript" src="' + ('https:' == document.location.protocol ? 'https://' : 'http://') + 'feed.mikle.com/js/rssmikle.js">\x3C/script>');</script>
-<script type="text/javascript">(function() {var params = {rssmikle_url: "https://in.pycon.org/blog/feeds/all.atom.xml",rssmikle_frame_width: "420",rssmikle_frame_height: "460",frame_height_by_article: "0",rssmikle_target: "_blank",rssmikle_font: "Arial, Helvetica, sans-serif",rssmikle_font_size: "12",rssmikle_border: "off",responsive: "off",rssmikle_css_url: "",text_align: "left",text_align2: "left",corner: "off",scrollbar: "on",autoscroll: "on",scrolldirection: "up",scrollstep: "3",mcspeed: "20",sort: "Off",rssmikle_title: "off",rssmikle_title_sentence: "PyCon India Blog",rssmikle_title_link: "",rssmikle_title_bgcolor: "#0066FF",rssmikle_title_color: "#FFFFFF",rssmikle_title_bgimage: "",rssmikle_item_bgcolor: "#FFFFFF",rssmikle_item_bgimage: "",rssmikle_item_title_length: "55",rssmikle_item_title_color: "#0E98C5",rssmikle_item_border_bottom: "on",rssmikle_item_description: "on",item_link: "off",rssmikle_item_description_length: "150",rssmikle_item_description_color: "#666666",rssmikle_item_date: "gl1",rssmikle_timezone: "Etc/GMT",datetime_format: "%b %e, %Y %l:%M:%S %p",item_description_style: "text+tn",item_thumbnail: "full",item_thumbnail_selection: "auto",article_num: "15",rssmikle_item_podcast: "off",keyword_inc: "",keyword_exc: ""};feedwind_show_widget_iframe(params);})();</script><div style="font-size:10px; text-align:center; width:320px;"><a href="http://feed.mikle.com/" target="_blank" style="color:#CCCCCC;">RSS Feed Widget</a><!--Please display the above link in your web page according to Terms of Service.--></div><!-- end feedwind code -->
+<script type="text/javascript">(function() {var params = {rssmikle_url: "https://in.pycon.org/blog/feeds/all.atom.xml",rssmikle_frame_width: "420",rssmikle_frame_height: "406",frame_height_by_article: "0",rssmikle_target: "_blank",rssmikle_font: "Arial, Helvetica, sans-serif",rssmikle_font_size: "12",rssmikle_border: "off",responsive: "off",rssmikle_css_url: "",text_align: "left",text_align2: "left",corner: "off",scrollbar: "on",autoscroll: "on",scrolldirection: "up",scrollstep: "3",mcspeed: "20",sort: "Off",rssmikle_title: "off",rssmikle_title_sentence: "PyCon India Blog",rssmikle_title_link: "",rssmikle_title_bgcolor: "#0066FF",rssmikle_title_color: "#FFFFFF",rssmikle_title_bgimage: "",rssmikle_item_bgcolor: "#FFFFFF",rssmikle_item_bgimage: "",rssmikle_item_title_length: "55",rssmikle_item_title_color: "#0E98C5",rssmikle_item_border_bottom: "on",rssmikle_item_description: "on",item_link: "off",rssmikle_item_description_length: "150",rssmikle_item_description_color: "#666666",rssmikle_item_date: "gl1",rssmikle_timezone: "Etc/GMT",datetime_format: "%b %e, %Y %l:%M:%S %p",item_description_style: "text+tn",item_thumbnail: "full",item_thumbnail_selection: "auto",article_num: "15",rssmikle_item_podcast: "off",keyword_inc: "",keyword_exc: ""};feedwind_show_widget_iframe(params);})();</script><div style="font-size:10px; text-align:center; width:320px;"><a href="http://feed.mikle.com/" target="_blank" style="color:#CCCCCC;">RSS Feed Widget</a><!--Please display the above link in your web page according to Terms of Service.--></div><!-- end feedwind code -->
 </script>
 <script type="text/javascript" src="js/rss-feed.js"></script>
 <!-- The link below helps keep this service FREE, and helps other people find the SW widget. Please be cool and keep it! Thanks. -->

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@ PYCON
                     <h5 class="date">
                 <i class="fa fa-calendar">
                 </i>
-                October 3 & 4, 2015
+                October 3 &amp; 4, 2015
               </h5>
                     <br/>
                     <a href="http://in.pycon.org/cfp/pycon-india-2015/proposals/" target="_blank" class="btn btn-pycon">

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -254,7 +254,7 @@
                     <h4>Note:</h4>
                     <ul>
                         <li>50% discount on silver category of sponsorship for startups with less than 10 employees.</li>
-                        <li>Stall will be available only during the main conference days (Saturday & Sunday).</li>
+                        <li>Stall will be available only during the main conference days (Saturday &amp; Sunday).</li>
                         <li>Amount expressed is in Indian Rupees.</li>
                         <li>Please get in touch with us, if you would like any customizations or add-ons to the benefits.</li>
                     </ul>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -26,7 +26,7 @@
     <meta name="description" content="PyCon India, the premier conference in India on using and developing the Python programming language is conducted annually by the Python developer community and it attracts the best Python programmers from across the country and abroad.">
     <meta name="author" content="Pycon India">
     <link rel="shortcut icon" href="favicon.png">
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic' rel='stylesheet' type='text/css'>
     <!-- Global CSS -->
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <!-- Plugins CSS -->
@@ -153,7 +153,7 @@
                     In order to ensure a successful conference, the community needs to address a wide range of logistical and organizational challenges. PyCon India attendees sometimes require assistance with expenses especially student attendees, and sponsorship enables us to support those who would otherwise be unable to attend.
                 </p>
                 <p>
-                    The attendees of PyCon India will include professional developers from large enterprises and smaller firms as well as people from academia. Delegates come to present their latest developments. With Python already becoming a major enterprise programming language and platform, sponsoring PyCon India 2015 is an excellent opportunity to demonstrate industry leadership in this part of the world. The attendance of PyCon India 2015 is expected to be between 1200 to 1350 delegates.
+                    The attendees of PyCon India will include professional developers from large enterprises and smaller firms as well as people from academia. Delegates come to present their latest developments. With Python already becoming a major enterprise programming language and platform, sponsoring PyCon India 2015 is an excellent opportunity to demonstrate industry leadership in this part of the world. The attendance of PyCon India 2015 is expected to be between 1200 and 1350 delegates.
                 </p>
                 <br/>
                 <h4> <a href="sponsorship_prospectus.pdf"> Download Sponsorship Prospectus </a></h4>
@@ -254,9 +254,9 @@
                     <h4>Note:</h4>
                     <ul>
                         <li>50% discount on silver category of sponsorship for startups with less than 10 employees.</li>
-                        <li>Stall will be available only during main conference days (Saturday & Sunday).</li>
+                        <li>Stall will be available only during the main conference days (Saturday & Sunday).</li>
                         <li>Amount expressed is in Indian Rupees.</li>
-                        <li>Please get it touch with us, if you would like any customizations or add-ons to the benefits.</li>
+                        <li>Please get in touch with us, if you would like any customizations or add-ons to the benefits.</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Fix the description to "It attracts the best Python programmers **from** across the country and abroad".

Load fonts over https instead of http. Fixes #8.

Center the map in the venue section in the mobile version and add some space between the map and the venue image. Currently, it shows up like this:

![image](https://cloud.githubusercontent.com/assets/7725225/9297963/da0f0170-44c4-11e5-8cad-b00f51efea65.png)

Resize the Twitter stream box to the same as that of the blog feed.  

Fix grammar and punctuation. 

Change & to `&amp;`
