### PR TITLE
Fix link to blog in navbar

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -85,7 +85,7 @@
                             <a href="index.html#sponsors">Sponsors</a>
                         </li>
                         <li class="nav-item">
-                            <a href="index.html#blog">Blog</a>
+                            <a href="https://in.pycon.org/blog/">Blog</a>
                         </li>
                         <li class="nav-item">
                             <a href="sponsorship.html">Sponsorship</a>

--- a/faq.html
+++ b/faq.html
@@ -91,7 +91,7 @@
                             <a href="index.html#sponsors">Sponsors</a>
                         </li>
                         <li class="nav-item">
-                            <a href="index.html#blog">Blog</a>
+                            <a href="https://in.pycon.org/blog/">Blog</a>
                         </li>
                         <li class="nav-item">
                             <a href="sponsorship.html">Sponsorship</a>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -101,7 +101,7 @@
               </a>
                         </li>
                         <li class="nav-item">
-                            <a href="index.html#blog">
+                            <a href="https://in.pycon.org/blog/">
                 Blog
               </a>
                         </li>


### PR DESCRIPTION
Fix the blog link in the navbar to point to https://in.pycon.org/blog/ instead of https://in.pycon.org/2015/index.html#blog.
