### PR TITLE
Remove whitespace above header

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ jQuery(document).ready(function($) {
     /* ======= Fixed header when scrolled ======= */
     
     $(window).bind('scroll', function() {
-         if ($(window).scrollTop() > 50) {
+         if ($(window).scrollTop() >= 5) {
              $('#header').addClass('navbar-fixed-top');
          }
          else {


### PR DESCRIPTION
Currently, the script brings the navbar(header) to the top only after the page is scrolled by 50 pixels. This leads to a noticeable whitespace in web and mobile.

![image](https://cloud.githubusercontent.com/assets/7725225/9313690/ef616cb6-4541-11e5-8a88-f58460771896.png)

This can be fixed by making the script move the header to the top after the page is scrolled by 5 pixels(the height of the blue-green gradient above the header). This is how it is after doing the suggested change:

![image](https://cloud.githubusercontent.com/assets/7725225/9313780/7967220c-4542-11e5-8932-37a097667310.png)
