### PR TITLE
fix(header/mobile): fix header menu displayed as transparent in mobile view

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -115,10 +115,10 @@ pre code {
     -webkit-box-shadow: 0 0 15px -2px rgba(0, 0, 0, 0.4);
     -moz-box-shadow: 0 0 15px -2px rgba(0, 0, 0, 0.4);
     box-shadow: 0 0 15px -2px rgba(0, 0, 0, 0.4);
+    z-index: 9999;
 }
 .header.navbar-fixed-top {
     background: rgba(255, 255, 255, 1);
-    z-index: 9999;
     -webkit-box-shadow: 0 0 15px -2px rgba(0, 0, 0, 0.4);
     -moz-box-shadow: 0 0 15px -2px rgba(0, 0, 0, 0.4);
     box-shadow: 0 0 15px -2px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
Bug:
<img width="556" alt="pycon_india_2015_in_bangalore___october_02nd_to_04th" src="https://cloud.githubusercontent.com/assets/236356/9856671/c4da1ff8-5b33-11e5-93eb-fb10ac72a6e2.png">
